### PR TITLE
Fixed newline check in server.py

### DIFF
--- a/lightstreamer_adapter/server.py
+++ b/lightstreamer_adapter/server.py
@@ -180,7 +180,7 @@ class _RequestReceiver():
                 tokens = buffer.splitlines(keepends=True)
                 buffer = ''
                 for token in tokens:
-                    if (token.endswith('\r\n')):
+                    if token.endswith('\n'):
                         self._log.debug("Request line: %s", token)
                         self._server.on_received_request(token)
                         buffer = ''


### PR DESCRIPTION
When the check used \r\n adapter was not parsing messages correctly, with \n it worked.